### PR TITLE
Add Docker Compose deployment and CI build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/gingerwax-flask:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.11-slim
 # Set environment variables for production
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    FLASK_ENV=production
+    FLASK_ENV=production \
+    FLASK_DEBUG=0
 
 # Set the working directory in the container
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -84,14 +84,31 @@ Start the server (Development)
   python app.py
 ```
 
+## Production Deployment
 
+The application ships with a Docker setup that is suited for production use with Gunicorn.
 
+1. Copy `.example.env` to `.env` and update the values.
+2. Build and start the stack using Docker Compose:
 
-## Deployment (with Docker)
+   ```bash
+   docker compose up --build -d
+   ```
 
-To deploy this project run
+   The app will be available on `http://localhost:5000` and runs with `FLASK_ENV=production` by default. A named volume `db_data` is created to persist the SQLite database.
+
+3. To stop the stack:
+
+   ```bash
+   docker compose down
+   ```
+
+### Using prebuilt images
+
+Every merge to the `main` branch triggers a GitHub Actions workflow that builds the Docker image and publishes it to the [GitHub Container Registry](https://ghcr.io/). You can pull and run the latest image without building locally:
 
 ```bash
-  docker run -p 5000:5000 --env-file .env gwcarti/gingerwax:latest
+docker pull ghcr.io/<your-github-username>/gingerwax-flask:latest
+docker run -p 5000:5000 --env-file .env ghcr.io/<your-github-username>/gingerwax-flask:latest
 ```
 

--- a/app.py
+++ b/app.py
@@ -16,19 +16,24 @@ from routes.order_routes import order_bp
 from routes.product_routes import product_bp
 from routes.shop_routes import shop_bp
 
-load_dotenv() # Load variables from .env file
+load_dotenv()  # Load variables from .env file
 
 # Create the database directory if it doesn't exist
-DATABASE_DIR = os.getenv('DATABASE_DIR')
+DATABASE_DIR = os.getenv("DATABASE_DIR", "")
 if len(DATABASE_DIR) > 0:
     os.makedirs(DATABASE_DIR, exist_ok=True)  # Ensure the directory exists
 
 # Setup the Flask app
 app = Flask(__name__)
-app.secret_key = os.environ.get('FLASK_SECRET_KEY')
-app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(DATABASE_DIR, 'app.db')}"
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.secret_key = os.environ.get("FLASK_SECRET_KEY")
+
+# Explicitly configure the environment
+app.config["ENV"] = os.getenv("FLASK_ENV", "production")
+app.config["DEBUG"] = app.config["ENV"] == "development"
+
+app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{os.path.join(DATABASE_DIR, 'app.db')}"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 
 csrf = CSRFProtect(app) # Enable CSRF protection 
 
@@ -97,4 +102,4 @@ app.register_blueprint(order_bp)
 app.register_blueprint(product_bp)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=app.config["DEBUG"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    environment:
+      FLASK_ENV: production
+      FLASK_DEBUG: 0
+    volumes:
+      - db_data:/app/data
+    restart: unless-stopped
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add docker-compose setup for running in production with Gunicorn
- configure Flask app to default to production environment and remove debug server
- document production deployment and GHCR workflow in README
- add workflow to build and push Docker image to GHCR on merges

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ⚠️ `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0931a490c8324840546e06840c4b6